### PR TITLE
Remove redundant npm dependency

### DIFF
--- a/package.json
+++ b/package.json
@@ -5,7 +5,6 @@
   "dependencies": {
     "@material-ui/core": "^4.0.0-rc.0",
     "animate.css": "^3.7.2",
-    "npm": "^6.9.0",
     "react": "^16.8.6",
     "react-animations": "^1.0.0",
     "react-dom": "^16.8.6",


### PR DESCRIPTION

Hello UlysesAColon!

It seems like you have npm as one of your (dev-) dependency in fermincolon.
Since you actually need npm to install the dependencies it's redundant to
have npm itself as (dev-) dependency. 

Therefore I've removed it and made this PR, merge if you want :)
Be sure to re-run `npm i` or `yarn` to actualize your lock files.

Beep boop, I'm a bot.
